### PR TITLE
add include to zlib

### DIFF
--- a/zlib/gzlib.c
+++ b/zlib/gzlib.c
@@ -4,6 +4,7 @@
  */
 
 #include "gzguts.h"
+#include "unistd.h"
 
 #if defined(_WIN32) && !defined(__BORLANDC__) && !defined(__MINGW32__)
 #  define LSEEK _lseeki64

--- a/zlib/gzread.c
+++ b/zlib/gzread.c
@@ -4,6 +4,7 @@
  */
 
 #include "gzguts.h"
+#include "unistd.h"
 
 /* Local functions */
 local int gz_load OF((gz_statep, unsigned char *, unsigned, unsigned *));

--- a/zlib/gzwrite.c
+++ b/zlib/gzwrite.c
@@ -4,6 +4,7 @@
  */
 
 #include "gzguts.h"
+#include "unistd.h"
 
 /* Local functions */
 local int gz_init OF((gz_statep));


### PR DESCRIPTION
When I compile (and use) this library, I got a lot of warnings like:

`# github.com/ipsn/go-libtor/libtor
In file included from ../../go/pkg/mod/github.com/ipsn/go-libtor@v1.0.116/libtor/zlib_gzlib.go:7:0:
../../go/pkg/mod/github.com/ipsn/go-libtor@v1.0.116/libtor/../zlib/gzlib.c: In function ‘gz_open’:
../../go/pkg/mod/github.com/ipsn/go-libtor@v1.0.116/libtor/../zlib/gzlib.c:14:17: warning: implicit declaration of function ‘lseek’ [-Wimplicit-function-declaration]
 `

This PR should avoid these warnings, adding specific includes.